### PR TITLE
GLTF scene nodes index fix.

### DIFF
--- a/examples/gltf.html
+++ b/examples/gltf.html
@@ -55,7 +55,8 @@
 		//var url = "data/Buggy.glb";
 		var url = "data/DamagedHelmet.glb";
 
-		var default_shader = new GL.Shader( renderer._vertex_shader, '\
+		// noinspection CheckValidXmlInScriptTagBody
+		var default_shader = new GL.Shader( renderer._vertex_shader, `\
 		precision highp float;\
 		varying vec2 v_coord;\
 		uniform vec4 u_color;\
@@ -67,7 +68,7 @@
 				discard;\n\
 			gl_FragColor = color;\
 		}\
-		');
+		`);
 		gl.shaders["gltf"] = default_shader;
 		renderer.default_shader_name = "gltf";
 

--- a/src/rendeer-gltf.js
+++ b/src/rendeer-gltf.js
@@ -216,9 +216,9 @@ RD.GLTF = {
 		for(var i = 0; i < nodes_info.length; ++i)
 		{
 			var info = nodes_info[i];
-			if(info.node)
+			if(typeof info !== "number")
 				continue;
-			var node = RD.GLTF.parseNode( null, i, json );
+			var node = RD.GLTF.parseNode( null, info, json );
 			if(!root)
 				root = node;
 			if(nodes_info.length > 1)


### PR DESCRIPTION
Fix to load files where the first node is not the scene root. 
And a minor change in gltf example so that IDE(Jetbrains) does not show an error with embedded glsl code.

Tested with: https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/CesiumMilkTruck
Without this commit, only wheels(of the truck) are loaded.